### PR TITLE
Add `JSObject` and `JSClass` abstractions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.1.0-alpha.3
+
+- Add runtime compilation/execution of JS snippets
+- Add `JSObject` abstraction
+- Add `JSClass` abstraction
+
 ## v0.1.0-alpha.2
 
 Adds a "Hello, world!" example that runs `trace("hello world\n");` in a new VM.

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test:
 cover: $(SOURCES)
 	dub test --parallel --coverage
 
-PACKAGE_VERSION := 0.1.0-alpha.2
+PACKAGE_VERSION := 0.1.0-alpha.3
 docs/sitemap.xml: $(SOURCES)
 	dub build -b ddox
 	@echo "Performing cosmetic changes..."

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ D bindings to the [XS JavaScript engine](https://github.com/Moddable-OpenSource/
 
 ```json
 "dependencies": {
-    "xs": "0.1.0-alpha.2"
+    "xs": "0.1.0-alpha.3"
 }
 ```
 

--- a/source/xs/bindings/enums.d
+++ b/source/xs/bindings/enums.d
@@ -38,37 +38,64 @@ enum JSType{
 
 ///
 enum JSError {
+  ///
   noError = 0,
+  ///
   unknownError = 1,
+  ///
   evalError = 2,
+  ///
   rangeError = 3,
+  ///
   referenceError = 4,
+  ///
   syntaxError = 5,
+  ///
   typeError = 6,
+  ///
   uriError = 7,
+  ///
   errorCount = 8,
 }
 
 ///
 enum MachineError {
-	debuggerExit = 0,
+	///
+  debuggerExit = 0,
+  ///
   notEnoughMemoryExit = 1,
+  ///
   stackOverflowExit = 2,
+  ///
   fatalCheckExit = 3,
+  ///
   deadStripExit = 4,
+  ///
   unhandledExceptionExit = 5,
+  ///
   noMoreKeysExit = 6,
+  ///
   tooMuchComputationExit = 7,
 }
 
 /// The attributes of a property.
 enum Attribute : xsAttribute {
+  /// Specifies that a property has no special attributes.
+  /// See_Also: `PropertyAttributes.none`
 	default_ = 0,
+  /// Specifies that the delete operation should fail on a property.
+  /// See_Also: `JSObject.deleteProperty`
 	dontDelete = 2,
+  /// Specifies that a property should not be enumerated by property enumerators and JavaScript `for...in` loops.
 	dontEnum = 4,
+  /// Specifies that a property is read-only.
 	dontSet = 8,
+  /// Specifies that a property is static.
 	static_ = 16,
+  /// Specifies that a property is a getter Function.
 	isGetter = 32,
+  /// Specifies that a property is a setter Function.
 	isSetter = 64,
+  ///
 	changeAll = 30
 }

--- a/source/xs/bindings/macros.d
+++ b/source/xs/bindings/macros.d
@@ -237,84 +237,84 @@ void* xsToArrayBuffer(scope xsMachine* the, xsSlot theSlot) {
 enum int prototypesStackIndex = -75;
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> on MDN
-enum xsSlot xsObjectPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 1];
+xsSlot xsObjectPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 1]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">Function</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">Function</a> on MDN
-enum xsSlot xsFunctionPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 2];
+xsSlot xsFunctionPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 2]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a> on MDN
-enum xsSlot xsArrayPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 3];
+xsSlot xsArrayPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 3]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a> on MDN
-enum xsSlot xsStringPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 4];
+xsSlot xsStringPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 4]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</a> on MDN
-enum xsSlot xsBooleanPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 5];
+xsSlot xsBooleanPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 5]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a> on MDN
-enum xsSlot xsNumberPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 6];
+xsSlot xsNumberPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 6]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date">Date</a> on MDN
-enum xsSlot xsDatePrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 7];
+xsSlot xsDatePrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 7]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp">RegExp</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp">RegExp</a> on MDN
-enum xsSlot xsRegExpPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 8];
+xsSlot xsRegExpPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 8]; }
 /// Returns a reference to the Host prototype instance created by the XS runtime.
-enum xsSlot xsHostPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 9];
+xsSlot xsHostPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 9]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Error</a> on MDN
-enum xsSlot xsErrorPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 10];
+xsSlot xsErrorPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 10]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/EvalError">EvalError</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/EvalError">EvalError</a> on MDN
-enum xsSlot xsEvalErrorPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 11];
+xsSlot xsEvalErrorPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 11]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RangeError">RangeError</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RangeError">RangeError</a> on MDN
-enum xsSlot xsRangeErrorPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 12];
+xsSlot xsRangeErrorPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 12]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError">ReferenceError</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError">ReferenceError</a> on MDN
-enum xsSlot xsReferenceErrorPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 13];
+xsSlot xsReferenceErrorPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 13]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError">SyntaxError</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError">SyntaxError</a> on MDN
-enum xsSlot xsSyntaxErrorPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 14];
+xsSlot xsSyntaxErrorPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 14]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError">TypeError</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError">TypeError</a> on MDN
-enum xsSlot xsTypeErrorPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 15];
+xsSlot xsTypeErrorPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 15]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/URIError">URIError</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/URIError">URIError</a> on MDN
-enum xsSlot xsURIErrorPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 16];
+xsSlot xsURIErrorPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 16]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError">AggregateError</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError">AggregateError</a> on MDN
-enum xsSlot xsAggregateErrorPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 17];
+xsSlot xsAggregateErrorPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 17]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol">Symbol</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol">Symbol</a> on MDN
-enum xsSlot xsSymbolPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 18];
+xsSlot xsSymbolPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 18]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">ArrayBuffer</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer">ArrayBuffer</a> on MDN
-enum xsSlot xsArrayBufferPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 19];
+xsSlot xsArrayBufferPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 19]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView">DataView</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView">DataView</a> on MDN
-enum xsSlot xsDataViewPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 20];
+xsSlot xsDataViewPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 20]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray">TypedArray</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray">TypedArray</a> on MDN
-enum xsSlot xsTypedArrayPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 21];
+xsSlot xsTypedArrayPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 21]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map">Map</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map">Map</a> on MDN
-enum xsSlot xsMapPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 22];
+xsSlot xsMapPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 22]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set">Set</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set">Set</a> on MDN
-enum xsSlot xsSetPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 23];
+xsSlot xsSetPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 23]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap">WeakMap</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap">WeakMap</a> on MDN
-enum xsSlot xsWeakMapPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 24];
+xsSlot xsWeakMapPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 24]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet">WeakSet</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet">WeakSet</a> on MDN
-enum xsSlot xsWeakSetPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 25];
+xsSlot xsWeakSetPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 25]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a> on MDN
-enum xsSlot xsPromisePrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 26];
+xsSlot xsPromisePrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 26]; }
 /// Returns a reference to the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">Proxy</a> prototype instance created by the XS runtime.
 /// See_Also: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy">Proxy</a> on MDN
-enum xsSlot xsProxyPrototype(alias xsMachine* the) = the.stackPrototypes[prototypesStackIndex - 27];
+xsSlot xsProxyPrototype(alias xsMachine* the)() { return the.stackPrototypes[prototypesStackIndex - 27]; }
 
 /// Creates an array instance, and returns a reference to the new array instance.
 ///

--- a/source/xs/bindings/macros.d
+++ b/source/xs/bindings/macros.d
@@ -767,14 +767,15 @@ xsSlot xsCallFunction(scope xsMachine* the, const xsSlot function_, const xsSlot
 ///
 /// Params:
 /// the=A machine
-/// this_=
-/// id=The identifier of the constructor to call
+/// this_=A reference to the instance that will have the constructor
+/// constructor=A reference to the constructor to call
 /// params=The parameter slots to pass to the constructor
-xsSlot xsNew(scope xsMachine* the, const xsSlot this_, int id, const xsSlot[] params ...) {
+xsSlot xsNew(scope xsMachine* the, const xsSlot this_, const xsSlot constructor, const xsSlot[] params ...) {
   assert(params.length >= 0);
 	xsOverflow(the, -XS_FRAME_COUNT - params.length.to!int);
 	fxPush(the, cast(xsSlot) this_);
-	fxNewID(the, id);
+  fxPush(the, cast(xsSlot) constructor);
+	fxNew(the);
   foreach (param; params) fxPush(the, cast(xsSlot) param);
 	fxRunCount(the, params.length.to!int);
 	return fxPop(the);
@@ -1377,7 +1378,7 @@ ReturnType!Func xsHostZone(alias Func)(scope xsMachine* the) if (isCallableAsHos
       else static assert(0, "Unreachable by design; " ~ __traits(identifier, T) ~ " has unsupported return type");
 
       fxEndHost(zonedThe);
-      the = null;
+      zonedThe = null;
     } else {
       try {
         fxAbort(hostThe, xsUnhandledExceptionExit);

--- a/source/xs/bindings/macros.d
+++ b/source/xs/bindings/macros.d
@@ -638,9 +638,9 @@ void xsDefineAt(scope xsMachine* the, const xsSlot this_, const xsSlot key, cons
 /// ---
 /// In D:
 /// ---
-/// xsDelete(xsGlobal, xsID_foo);
-/// xsDelete(xsThis, xsID_foo);
-/// xsDelete(xsThis, 0);
+/// the.xsDelete(xsGlobal, xsID_foo);
+/// the.xsDelete(xsThis, xsID_foo);
+/// the.xsDelete(xsThis, 0);
 /// ---
 void xsDelete(scope xsMachine* the, const xsSlot this_, int key) {
 	the.xsOverflow(-1);
@@ -666,8 +666,8 @@ void xsDelete(scope xsMachine* the, const xsSlot this_, int key) {
 /// ---
 /// In D:
 /// ---
-/// xsDeleteAt(xsThis, xsID_foo);
-/// xsDeleteAt(xsThis, xsInteger(0));
+/// the.xsDeleteAt(xsThis, xsID_foo);
+/// the.xsDeleteAt(xsThis, xsInteger(0));
 /// ---
 void xsDeleteAt(scope xsMachine* the, const xsSlot this_, const xsSlot key) {
 	the.xsOverflow(-2);

--- a/source/xs/bindings/macros.d
+++ b/source/xs/bindings/macros.d
@@ -602,21 +602,21 @@ void xsSetAt(scope xsMachine* the, const xsSlot this_, const xsSlot key, const x
 /// ---
 /// machine.xsDefine(xsThis, xsID_foo, xsInteger(7), xsDefault);
 /// ---
-void xsDefine(scope xsMachine* the, xsSlot this_, int id, xsSlot slot, Attribute attributes) {
+void xsDefine(scope xsMachine* the, const xsSlot this_, xsIndex id, const xsSlot slot, xsAttribute attributes) {
 	the.xsOverflow(-2);
-	the.fxPush(slot);
-	the.fxPush(this_);
-	fxDefineID(the, id, attributes, attributes | xsDontDelete | xsDontEnum | xsDontSet);
+	the.fxPush(cast(xsSlot) slot);
+	the.fxPush(cast(xsSlot) this_);
+	fxDefineID(the, id, attributes, attributes | xsDontDelete | xsDontSet);
 	the.stack++;
 }
 
 ///
-void xsDefineAt(scope xsMachine* the, xsSlot this_, xsSlot key, xsSlot slot, Attribute attributes) {
+void xsDefineAt(scope xsMachine* the, const xsSlot this_, const xsSlot key, const xsSlot slot, xsAttribute attributes) {
 	the.xsOverflow(-3);
-	the.fxPush(slot);
-	the.fxPush(this_);
-	the.fxPush(key);
-	fxDefineAt(the, attributes, attributes | xsDontDelete | xsDontEnum | xsDontSet);
+	the.fxPush(cast(xsSlot) slot);
+	the.fxPush(cast(xsSlot) this_);
+	the.fxPush(cast(xsSlot) key);
+	fxDefineAt(the, attributes, attributes | xsDontDelete | xsDontSet);
 	the.stack++;
 }
 

--- a/source/xs/bindings/macros.d
+++ b/source/xs/bindings/macros.d
@@ -520,10 +520,10 @@ xsSlot xsGet(scope xsMachine* the, const xsSlot this_, int id) {
 /// xsVar(0) = xsGet(xsThis, xsID_foo);
 /// xsVar(1) = xsGetAt(xsVar(0), xsInteger(3));
 /// ---
-xsSlot xsGetAt(scope xsMachine* the, xsSlot this_, xsSlot key) {
+xsSlot xsGetAt(scope xsMachine* the, const xsSlot this_, const xsSlot key) {
 	the.xsOverflow(-2);
-	the.fxPush(this_);
-	the.fxPush(key);
+	the.fxPush(cast(xsSlot) this_);
+	the.fxPush(cast(xsSlot) key);
 	fxGetAt(the);
 	return the.fxPop();
 }
@@ -549,7 +549,7 @@ xsSlot xsGetAt(scope xsMachine* the, xsSlot this_, xsSlot key) {
 /// xsSet(xsThis, xsID_foo, xsInteger(1));
 /// xsSet(xsThis, 0, xsInteger(2));
 /// ---
-void xsSet(scope xsMachine* the, const xsSlot this_, int id, const xsSlot slot) {
+void xsSet(scope xsMachine* the, const xsSlot this_, xsIndex id, const xsSlot slot) {
 	the.xsOverflow(-2);
 	the.fxPush(cast(xsSlot) slot);
 	the.fxPush(cast(xsSlot) this_);
@@ -576,11 +576,11 @@ void xsSet(scope xsMachine* the, const xsSlot this_, int id, const xsSlot slot) 
 /// xsVar(0) = xsGet(xsThis, xsID_foo);
 /// xsSetAt(xsVar(0), xsInteger(3), xsInteger(7));
 /// ---
-void xsSetAt(scope xsMachine* the, xsSlot this_, xsSlot key, xsSlot slot) {
+void xsSetAt(scope xsMachine* the, const xsSlot this_, const xsSlot key, const xsSlot slot) {
 	the.xsOverflow(-3);
-	the.fxPush(slot);
-	the.fxPush(this_);
-	the.fxPush(key);
+	the.fxPush(cast(xsSlot) slot);
+	the.fxPush(cast(xsSlot) this_);
+	the.fxPush(cast(xsSlot) key);
 	fxSetAt(the);
 	the.stack++;
 }
@@ -642,9 +642,9 @@ void xsDefineAt(scope xsMachine* the, xsSlot this_, xsSlot key, xsSlot slot, Att
 /// xsDelete(xsThis, xsID_foo);
 /// xsDelete(xsThis, 0);
 /// ---
-void xsDelete(scope xsMachine* the, xsSlot this_, int key) {
+void xsDelete(scope xsMachine* the, const xsSlot this_, int key) {
 	the.xsOverflow(-1);
-	the.fxPush(this_);
+	the.fxPush(cast(xsSlot) this_);
 	fxDeleteID(the, key);
 	the.stack++;
 }
@@ -669,10 +669,10 @@ void xsDelete(scope xsMachine* the, xsSlot this_, int key) {
 /// xsDeleteAt(xsThis, xsID_foo);
 /// xsDeleteAt(xsThis, xsInteger(0));
 /// ---
-void xsDeleteAt(scope xsMachine* the, xsSlot this_, xsSlot key) {
+void xsDeleteAt(scope xsMachine* the, const xsSlot this_, const xsSlot key) {
 	the.xsOverflow(-2);
-	the.fxPush(this_);
-	the.fxPush(key);
+	the.fxPush(cast(xsSlot) this_);
+	the.fxPush(cast(xsSlot) key);
 	fxDeleteAt(the);
 	the.stack++;
 }
@@ -705,11 +705,11 @@ enum int XS_FRAME_COUNT = 6;
 /// xsCall(xsThis, xsID_foo, xsInteger(1));
 /// xsCall(xsThis, 0, xsInteger(2), xsInteger(3));
 /// ---
-xsSlot xsCall(scope xsMachine* the, xsSlot this_, int id, xsSlot[] params ...) {
+xsSlot xsCall(scope xsMachine* the, const xsSlot this_, xsIndex id, const xsSlot[] params ...) {
   assert(params.length >= 0);
 	the.xsOverflow(-XS_FRAME_COUNT - params.length.to!int);
-	the.fxPush(this_);
-  foreach (param; params) fxPush(the, param);
+	the.fxPush(cast(xsSlot) this_);
+  foreach (param; params) fxPush(the, cast(xsSlot) param);
 	fxCallID(the, id);
 	fxRunCount(the, params.length.to!int);
 	return the.fxPop();
@@ -722,11 +722,11 @@ xsSlot xsCall(scope xsMachine* the, xsSlot this_, int id, xsSlot[] params ...) {
 /// this_=A reference to the instance that will have the property or item
 /// id=The identifier of the property or item to call
 /// params=The parameter slots to pass to the function
-void xsCall_noResult(scope xsMachine* the, xsSlot this_, int id, xsSlot[] params ...) {
+void xsCall_noResult(scope xsMachine* the, const xsSlot this_, xsIndex id, const xsSlot[] params ...) {
   assert(params.length >= 0);
 	the.xsOverflow(-XS_FRAME_COUNT - params.length.to!int);
-	the.fxPush(this_);
-  foreach (param; params) fxPush(the, param);
+	the.fxPush(cast(xsSlot) this_);
+  foreach (param; params) fxPush(the, cast(xsSlot) param);
 	fxCallID(the, id);
 	fxRunCount(the, params.length.to!int);
 	the.stack++;

--- a/source/xs/bindings/macros.d
+++ b/source/xs/bindings/macros.d
@@ -367,10 +367,10 @@ xsSlot xsNewObject(scope xsMachine* the) {
 /// the=A machine
 /// instance=A reference to the instance to test
 /// prototype=A reference to the prototype to test
-bool xsIsInstanceOf(scope xsMachine* the, xsSlot instance, xsSlot prototype) {
+bool xsIsInstanceOf(scope xsMachine* the, const xsSlot instance, const xsSlot prototype) {
 	the.xsOverflow(-2);
-	the.fxPush(prototype);
-	the.fxPush(instance);
+	the.fxPush(cast(xsSlot) prototype);
+	the.fxPush(cast(xsSlot) instance);
 	return fxIsInstanceOf(the).to!bool;
 }
 
@@ -464,10 +464,10 @@ bool xsHas(scope xsMachine* the, const xsSlot this_, int id) {
 /// ---
 /// if (xsHasAt(xsThis, xsInteger(7)));
 /// ---
-bool xsHasAt(scope xsMachine* the, xsSlot this_, xsSlot key) {
+bool xsHasAt(scope xsMachine* the, const xsSlot this_, const xsSlot key) {
 	the.xsOverflow(-2);
-	the.fxPush(this_);
-	the.fxPush(key);
+	the.fxPush(cast(xsSlot) this_);
+	the.fxPush(cast(xsSlot) key);
 	return fxHasAt(the).to!bool;
 }
 
@@ -738,13 +738,13 @@ void xsCall_noResult(scope xsMachine* the, xsSlot this_, int id, xsSlot[] params
 /// function_=
 /// this_=
 /// params=The parameter slots to pass to the function
-xsSlot xsCallFunction(scope xsMachine* the, xsSlot function_, xsSlot this_, xsSlot[] params ...) {
+xsSlot xsCallFunction(scope xsMachine* the, const xsSlot function_, const xsSlot this_, const xsSlot[] params ...) {
   assert(params.length >= 0);
 	xsOverflow(the, -XS_FRAME_COUNT - params.length.to!int);
-	fxPush(the, this_);
-	fxPush(the, function_);
+	fxPush(the, cast(xsSlot) this_);
+	fxPush(the, cast(xsSlot) function_);
 	fxCall(the);
-	foreach (param; params) fxPush(the, param);
+	foreach (param; params) fxPush(the, cast(xsSlot) param);
 	fxRunCount(the, params.length.to!int);
 	return fxPop(the);
 }
@@ -755,12 +755,12 @@ xsSlot xsCallFunction(scope xsMachine* the, xsSlot function_, xsSlot this_, xsSl
 /// this_=
 /// id=The identifier of the constructor to call
 /// params=The parameter slots to pass to the constructor
-xsSlot xsNew(scope xsMachine* the, xsSlot this_, int id, xsSlot[] params ...) {
+xsSlot xsNew(scope xsMachine* the, const xsSlot this_, int id, const xsSlot[] params ...) {
   assert(params.length >= 0);
 	xsOverflow(the, -XS_FRAME_COUNT - params.length.to!int);
-	fxPush(the, this_);
+	fxPush(the, cast(xsSlot) this_);
 	fxNewID(the, id);
-  foreach (param; params) fxPush(the, param);
+  foreach (param; params) fxPush(the, cast(xsSlot) param);
 	fxRunCount(the, params.length.to!int);
 	return fxPop(the);
 }
@@ -883,14 +883,14 @@ void xsCollectGarbage(scope xsMachine* the) {
 void xsEnableGarbageCollection(scope xsMachine* the, bool enableIt) {
 	fxEnableGarbageCollection(the, enableIt);
 }
-void xsRemember(scope xsMachine* the, xsSlot slot) {
-	fxRemember(the, &slot);
+void xsRemember(scope xsMachine* the, const xsSlot slot) {
+	fxRemember(the, cast(xsSlot*) &slot);
 }
-void xsForget(scope xsMachine* the, xsSlot slot) {
-	fxForget(the, &slot);
+void xsForget(scope xsMachine* the, const xsSlot slot) {
+	fxForget(the, cast(xsSlot*) &slot);
 }
-void xsAccess(scope xsMachine* the, xsSlot slot) {
-	fxAccess(the, &slot);
+void xsAccess(scope xsMachine* the, const xsSlot slot) {
+	fxAccess(the, cast(xsSlot*) &slot);
 }
 
 // Exceptions
@@ -1279,6 +1279,7 @@ private template illegallyEscapesScope(Param, alias ParamStorage) {
 /// See_Also:
 /// $(UL
 ///   $(LI `xsHostZone`)
+///   $(LI `JSObject.makeFunction`)
 ///   $(LI From the <a href="https://github.com/Moddable-OpenSource/moddable/blob/OS201116/documentation/xs/XS%20in%20C.md#xs-in-c">XS in C</a> Moddable SDK <a href="https://github.com/Moddable-OpenSource/moddable/tree/OS201116/documentation#readme">Documentation</a>:)
 ///   $(UL
 ///     $(LI <a href="https://github.com/Moddable-OpenSource/moddable/blob/OS201116/documentation/xs/XS%20in%20C.md#host">Host</a>)

--- a/source/xs/bindings/structs.d
+++ b/source/xs/bindings/structs.d
@@ -7,9 +7,50 @@ module xs.bindings.structs;
 
 import xs.bindings;
 
+alias txFlag = txU1;
 alias txID = txS2;
+alias txBoolean = txS4;
+alias txInteger = txS4;
+alias txKind = txS1;
 alias txSize = txS4;
+alias txNumber = double;
 alias txString = char*;
+
+package(xs) struct txBigInt {
+	txU4* data;
+	txU2 size;
+	txU1 sign;
+}
+
+package(xs) union txValue {
+	txBoolean boolean;
+	txInteger integer;
+	txNumber number;
+	txString string_;
+	txID symbol;
+	txBigInt bigint;
+
+	sxSlot* reference;
+
+	sxSlot* closure;
+}
+
+package(xs) struct sxSlot {
+	sxSlot* next;
+	union {
+		struct {
+			txKind kind;
+			txFlag flag;
+			txID ID;
+		}
+		txInteger KIND_FLAG_ID;
+	}
+// #if (!defined(linux)) && ((defined(__GNUC__) && defined(__LP64__)) || (defined(_MSC_VER) && defined(_M_X64)))
+// 	// Made it aligned and consistent on all platforms
+// 	txInteger dummy;
+// #endif
+	txValue value;
+}
 
 /// Empty checksum of a prepared VM
 static txU1[16] emptyChecksum = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
@@ -94,6 +135,52 @@ struct txScript {
     assert(script.hostsBuffer);
     auto hosts = script.hostsBuffer[0..hostsSize];
     assert(hostsBuffer[0..hostsSize].copy(hosts).length == 0);
+
+    import core.stdc.string : strlen;
+
+    if (path !is null) {
+      const pathSlice = path[0..path.strlen];
+      script.path = cast(char*) malloc(pathSlice.length);
+      assert(script.path);
+      assert(pathSlice.copy(script.path[0..pathSlice.length]).length == 0);
+    }
+
+    return script;
+  }
+
+  txScript* managedCopy() @property const {
+    import core.stdc.string : strlen;
+    import std.algorithm : copy;
+
+    auto pathSlice = path is null ? new char[0] : path[0..path.strlen];
+    auto script = new txScript(
+      cast(void*) callback,
+      symbolsSize ? new txS1[symbolsSize].ptr : null, symbolsSize,
+      codeSize ? new txS1[codeSize].ptr : null, codeSize,
+      hostsSize ? new txS1[hostsSize].ptr : null, hostsSize,
+      path is null ? null : new char[pathSlice.length].ptr, version_
+    );
+    assert(script);
+
+    if (script.symbolsBuffer) {
+      auto symbols = script.symbolsBuffer[0..symbolsSize];
+      assert(symbolsBuffer[0..symbolsSize].copy(symbols).length == 0);
+    }
+
+    if (script.codeBuffer) {
+      auto code = script.codeBuffer[0..codeSize];
+      assert(codeBuffer[0..codeSize].copy(code).length == 0);
+    }
+
+    if (script.hostsBuffer) {
+      auto hosts = script.hostsBuffer[0..hostsSize];
+      assert(hostsBuffer[0..hostsSize].copy(hosts).length == 0);
+    }
+
+    if (path !is null) {
+      assert(script.path);
+      assert(pathSlice.copy(script.path[0..pathSlice.length]).length == 0);
+    }
 
     return script;
   }

--- a/source/xs/bindings/structs.d
+++ b/source/xs/bindings/structs.d
@@ -33,6 +33,10 @@ package(xs) union txValue {
 	sxSlot* reference;
 
 	sxSlot* closure;
+
+  // https://github.com/Moddable-OpenSource/moddable/blob/OS201116/xs/sources/xsAll.h#L272
+  struct module_anon { sxSlot* realm; txID id; }
+  module_anon module_;
 }
 
 package(xs) struct sxSlot {

--- a/source/xs/package.d
+++ b/source/xs/package.d
@@ -149,6 +149,7 @@ class Machine {
     if (the && the.context) the.xsDeleteMachine();
   }
 
+  /// Create a Machine given a `xsMachine`.
   static Machine from(xsMachine* the) {
     return new Machine(the);
   }

--- a/source/xs/package.d
+++ b/source/xs/package.d
@@ -366,3 +366,339 @@ unittest {
   machine.collectGarbage();
   destroy(machine);
 }
+
+/// A JavaScript Object reference.
+///
+/// Adapted from <a href="https://developer.apple.com/documentation/javascriptcore/jsobjectref_h">`JSObjectRef`</a> in Apple's <a href="https://developer.apple.com/documentation/javascriptcore">JavaScriptCore</a>.
+class JSObject : JSValue {
+  import std.algorithm : map;
+  import std.array : array;
+
+  private void* _data;
+
+  ///
+  /// Params:
+  /// machine=A `Machine`.
+  /// value=
+  /// data=The Object’s private data.
+  this(Machine machine, const xsSlot value, void* data = null) {
+    super(machine, value);
+    this._data = data;
+  }
+
+  /// Creates a JavaScript Object.
+  ///
+  /// Params:
+  /// machine=A `Machine`.
+  /// data=The Object’s private data.
+  /// Returns: A `JSObject` with the given class and private data.
+  static JSObject make(Machine machine, void* data = null) {
+    auto objectSlot = xsNewObject(machine.the);
+    // TODO: Set user data
+
+    return new JSObject(machine, objectSlot, data);
+  }
+
+  /// Creates a JavaScript Array object.
+  ///
+  /// Params:
+  /// machine=A `Machine`.
+  /// length=Length of the returned Array.
+  /// Returns: A `JSObject` that is an Array.
+  static JSObject makeArray(Machine machine, uint length) {
+    return new JSObject(machine, xsNewArray(machine.the, length));
+  }
+
+  /// Creates a JavaScript Date object, as if by invoking the built-in Date constructor.
+  ///
+  /// Params:
+  /// machine=A `Machine`.
+  /// arguments=Arguments to pass to the Date constructor.
+  /// Returns: A `JSObject` that is a Date.
+  ///
+  /// Throws: `JSException` when the JS VM is aborted with the `xsUnhandledExceptionExit` status.
+  static JSObject makeDate(Machine machine, JSValue[] arguments ...) {
+    auto the = machine.the;
+    auto objectSlot = xsNew(
+      the, machine.global,
+      machine.toId(xsDatePrototype!the),
+      arguments.map!(arg => arg.slot).array
+    );
+    return new JSObject(machine, objectSlot);
+  }
+
+  /// Creates a JavaScript Error object, as if by invoking the built-in Error constructor.
+  ///
+  /// Params:
+  /// machine=A `Machine`.
+  /// arguments=Arguments to pass to the Error constructor.
+  /// Returns: A `JSObject` that is an Error.
+  ///
+  /// Throws: `JSException` when the JS VM is aborted with the `xsUnhandledExceptionExit` status.
+  static JSObject makeError(Machine machine, JSValue[] arguments ...) {
+    auto the = machine.the;
+    auto objectSlot = xsNew(
+      the, machine.global,
+      machine.toId(xsErrorPrototype!the),
+      arguments.map!(arg => arg.slot).array
+    );
+    return new JSObject(machine, objectSlot);
+  }
+
+  /// Creates a function with a given script as its body.
+  ///
+  /// Params:
+  /// machine=A `Machine`.
+  /// name=The function's name
+  /// parameterNames=The names of the function's parameters.
+  /// body=The script to use as the function's body.
+  /// path=A URL for the script's source file. This is only used when reporting exceptions. Pass `null` if you do not care to include source file information in exceptions.
+  /// startingLineNumber=An integer value specifying the script's starting line number in the file located at `path`. This is only used when reporting exceptions.
+  /// exception=A pointer to a JSValue in which to store a syntax error exception, if any. Pass `null` if you do not care to store a syntax error exception.
+  static JSObject makeFunction(
+    Machine machine, string name, string[] parameterNames, string body, string path, uint startingLineNumber,
+    out JSValue exception
+  ) {
+    assert(0, "Not implemented");
+  }
+
+  /// Creates a function with the given callback, `Func` as its implementation.
+  ///
+  /// Params:
+  /// machine=A `Machine`.
+  ///
+  /// See_Also: `isCallableAsHostZone`
+  static JSObject makeFunction(Func)(Machine machine) if (isCallableAsHostZone!Func) {
+    assert(0, "Not implemented");
+  }
+
+  /// Creates a JavaScript RegExp object, as if by invoking the built-in RegExp constructor.
+  ///
+  /// Params:
+  /// machine=A `Machine`.
+  static JSObject makeRegExp(Machine machine) {
+    auto the = machine.the;
+    auto objectSlot = xsNew(the, machine.global, machine.toId(xsRegExpPrototype!the));
+    return new JSObject(machine, objectSlot);
+  }
+
+  /// This Object’s private data.
+  void* data() @property const {
+    return cast(void*) _data;
+  }
+
+  /// Gets this object’s prototype.
+  JSValue prototype() @property const {
+    return null;
+  }
+
+  /// Sets this object’s prototype.
+  void prototype(JSValue value) @property {
+    return;
+  }
+
+  /// Whether this Object can be called as a constructor.
+  bool constructor() @property const {
+    auto the = machine.the;
+    return xsIsInstanceOf(the, slot, xsObjectPrototype!the);
+  }
+
+  /// Whether this Object can be called as a function.
+  bool function_() @property const {
+    return false;
+  }
+
+  /// The names of this Object’s enumerable properties.
+  string[] propertyNames() @property const {
+    return [];
+  }
+
+  /// Tests whether this Object has a given property.
+  bool hasProperty(string key) {
+    return xsHas(machine.the, slot, machine.id(key));
+  }
+
+  /// Tests whether this Object has a property given its numeric index.
+  bool hasPropertyAt(uint id) {
+    return xsHasAt(machine.the, slot, machine.the.xsUnsigned(id));
+  }
+
+  /// Gets a property from this Object.
+  JSValue getProperty(string key) {
+    return null;
+  }
+
+  /// Gets a property from this Object given its numeric index.
+  JSValue getPropertyAt(uint id) {
+    return null;
+  }
+
+  /// Sets a property from this Object.
+  void setProperty(string key) {
+    return;
+  }
+
+  /// Sets a property from this Object given its numeric index.
+  void setPropertyAt(uint id) {
+    return;
+  }
+
+  /// Deletes a property from this Object.
+  bool deleteProperty() {
+    return false;
+  }
+
+  /// Calls this Object as a constructor.
+  JSObject callAsContructor(JSValue[] params ...) {
+    assert(0, "Not implemented");
+  }
+
+  /// Calls this Object as a Function.
+  JSValue callAsFunction(JSValue[] params ...) {
+    assert(0, "Not implemented");
+  }
+
+  /// Calls this Object as a Function.
+  void callAsFunction_noResult(JSValue[] params ...) {
+    assert(0, "Not implemented");
+  }
+}
+
+/// A set of JSObject property attributes. Combine multiple attributes with bitwise OR.
+enum PropertyAttributes {
+  /// Specifies that a property has no special attributes.
+  none = 0,
+  /// Specifies that a property is read-only.
+  readOnly = xsDontSet,
+  /// Specifies that a property is read-only.
+  dontSet = xsDontSet,
+  /// Specifies that a property should not be enumerated by property enumerators and JavaScript `for...in` loops.
+  dontEnumerate = xsDontEnum,
+  /// Specifies that the delete operation should fail on a property.
+  /// See_Also: `JSObject.deleteProperty`
+  dontDelete = xsDontDelete,
+  /// Specifies that a property is static.
+  static_ = xsStatic,
+  /// Specifies that a property is a getter Function.
+  isGetter = xsIsGetter,
+  /// Specifies that a property is a setter Function.
+  isSetter = xsIsSetter,
+  ///
+  changeAll = xsChangeAll,
+}
+
+/// A set of `JSClass` attributes. Combine multiple attributes with bitwise OR.
+/// See_Also: `ClassDefinition.attributes`
+enum ClassAttributes {
+  /// Specifies that a class has no special attributes.
+  none = 0,
+  /// Specifies that a class should not automatically generate a shared prototype for its instance objects.
+  noAutomaticPrototype = 2
+}
+
+/// Describes a statically declared function property.
+///
+/// Adapted from <a href="https://developer.apple.com/documentation/javascriptcore/jsstaticfunction">`JSStaticFunction`</a> in Apple's <a href="https://developer.apple.com/documentation/javascriptcore">JavaScriptCore</a>.
+struct JSStaticFunction {
+  ///
+  string name;
+  /// A set of property attributes. Combine multiple attributes with bitwise OR.
+  PropertyAttributes attributes;
+  ///
+  xsCallback callAsFunction;
+}
+
+/// Describes a statically declared value property.
+///
+/// Adapted from <a href="https://developer.apple.com/documentation/javascriptcore/jsstaticvalue">`JSStaticValue`</a> in Apple's <a href="https://developer.apple.com/documentation/javascriptcore">JavaScriptCore</a>.
+struct JSStaticValue {
+  ///
+  string name;
+  /// A set of property attributes. Combine multiple attributes with bitwise OR.
+  PropertyAttributes attributes;
+  /// Invoked when getting this property’s value.
+  ///
+  /// If this function returns `null`, the get request forwards to object’s statically declared properties, then its parent class chain (which includes the default Object class), then its prototype chain.
+  xsCallback getProperty;
+  /// Invoked when setting this property’s value.
+  ///
+  /// If this function returns `null`, the get request forwards to object’s statically declared properties, then its parent class chain (which includes the default Object class), then its prototype chain.
+  xsCallback setProperty;
+}
+
+/// Properties and callbacks that define a type of Object.
+/// All fields other than the version field are optional. Any pointer may be `null`.
+///
+/// Adapted from <a href="https://developer.apple.com/documentation/javascriptcore/jsclassdefinition">`JSClassDefinition`</a> in Apple's <a href="https://developer.apple.com/documentation/javascriptcore">JavaScriptCore</a>.
+struct ClassDefinition {
+  ///
+  string name;
+  ///
+  JSClass parentClass;
+  /// A set of attributes. Combine multiple attributes with bitwise OR.
+  ClassAttributes attributes;
+  /// Invoked when an object is first created.
+  xsCallback initialize;
+  /// Invoked when an object is finalized (prepared for garbage collection). An Object may be finalized on any thread.
+  xsCallback finalize;
+  ///
+  xsDestructor destructor;
+  // xsCallback callAsConstructor; TODO: Not a thing in XS?
+  // xsCallback callAsFunction; TODO: Not a thing in XS?
+  // xsCallback hasInstance; TODO: Not a thing in XS?
+  /// Invoked when determining whether an Object has a property.
+  xsCallback hasProperty;
+  ///
+  xsCallback getPropertyNames;
+  /// Invoked when getting a property’s value.
+  ///
+  /// If this function returns `null`, the get request forwards to object’s statically declared properties, then its parent class chain (which includes the default Object class), then its prototype chain.
+  xsCallback getProperty;
+  /// Invoked when setting a property’s value.
+  ///
+  /// If this function returns `null`, the get request forwards to object’s statically declared properties, then its parent class chain (which includes the default Object class), then its prototype chain.
+  xsCallback setProperty;
+  ///
+  xsCallback deleteProperty;
+  // xsCallback convertToType; TODO: Not a thing in XS?
+  /// Statically declared function properties on the class' prototype.
+  JSStaticFunction[] staticFunctions;
+  /// Statically declared value properties on the class' prototype.
+  JSStaticValue[] staticValues;
+  ///
+  int version_;
+}
+
+/// A JavaScript class. Subclass a D class with `JSClass` to expose it to a JS VM.
+///
+/// Use with `JSObject.make` to construct objects with custom behavior.
+///
+/// Adapted from <a href="https://developer.apple.com/documentation/javascriptcore/jsclassref">`JSClassRef`</a> in Apple's <a href="https://developer.apple.com/documentation/javascriptcore">JavaScriptCore</a>.
+abstract class JSClass {
+  private JSObject _instance;
+  ///
+  const ClassDefinition definition;
+
+  /// Constructs a JavaScript class suitable for use with `JSObject.make`.
+  this(ClassDefinition definition) {
+    this.definition = definition;
+  }
+
+  /// Retains this JavaScript class.
+  void retain() {
+    remember();
+  }
+  /// Remembers this JavaScript class.
+  void remember() {
+    xsRemember(_instance.machine.the, _instance.slot);
+  }
+
+  /// Releases this JavaScript class.
+  void release() {
+    forget();
+  }
+  /// Forgets this JavaScript class.
+  void forget() {
+    xsForget(_instance.machine.the, _instance.slot);
+  }
+}

--- a/source/xs/script.d
+++ b/source/xs/script.d
@@ -39,7 +39,7 @@ class Script {
 	const string path;
 
   /// Construct a new script given its source code.
-  this(Machine machine, string path, const(byte[]) source) {
+  this(Machine machine, string path, const(ubyte[]) source) {
     this.machine = machine;
     this.script = txScript();
 
@@ -76,7 +76,9 @@ class Script {
     try {
       machine.the.xsHostZone!zone;
     } catch (JSException unhandledInVm) {
-      throw new JSException(unhandledInVm.msg, this, unhandledInVm.file, unhandledInVm.line);
+      // TODO: Get the JS error that was thrown
+      const JSValue exception = null;
+      throw new JSException(unhandledInVm.msg, this, exception, unhandledInVm.file, unhandledInVm.line);
     }
   }
 }

--- a/source/xs/script.d
+++ b/source/xs/script.d
@@ -1,4 +1,4 @@
-/// JavaScript script and module loaders.
+/// JavaScript program and module loaders.
 ///
 /// Authors: Chance Snow
 /// Copyright: Copyright © 2020 Chance Snow. All rights reserved.
@@ -84,7 +84,7 @@ class JSParseException : Exception {
   mixin basicExceptionCtors;
 }
 
-/// A JavaScript script or entry point module.
+/// A JavaScript program or entry point module.
 class Script {
   private Machine machine;
   package(xs) const txScript script;
@@ -101,10 +101,10 @@ class Script {
   ///
 	const txS1[] hostsBuffer;
 
-  /// Construct a new script given its source code and load it, executing its global scope in the given `machine`.
+  /// Construct a new script given its source code and load it, executing its outer-most scope in the given `machine`.
   ///
   /// Throws: `JSParseException` when the script fails to parse
-  /// Throws: `JSException` when the JS VM is aborted with the `xsUnhandledExceptionExit` status while executing the script's global scope
+  /// Throws: `JSException` when the JS VM is aborted with the `xsUnhandledExceptionExit` status while executing the script's outer-most scope
   this(Machine machine, string source, string* path = null, ScriptKind kind = ScriptKind.program) {
     import std.exception : enforce;
 
@@ -135,7 +135,9 @@ class Script {
 
     run();
   }
-  /// Construct a script given compiled VM byte code.
+  /// Construct a script given compiled VM byte code and load it, executing its outer-most scope in the given `machine`.
+  ///
+  /// Throws: `JSException` when the JS VM is aborted with the `xsUnhandledExceptionExit` status while executing the script's outer-most scope
   this(Machine machine, const txScript* byteCode, ScriptKind kind = ScriptKind.program) {
     import std.string : fromStringz;
 

--- a/source/xs/script.d
+++ b/source/xs/script.d
@@ -13,12 +13,14 @@ import xs.bindings.enums;
 import xs.bindings.structs;
 
 package(xs) enum mxProgramStackIndex = 2;
-package(xs) auto mxProgram(xsMachine* the) { return the.stackTop[-1 - mxProgramStackIndex]; }
-package(xs) xsSlot* next(const xsSlot slot) {
-  return cast(xsSlot*) slot.data[0];
+package(xs) sxSlot mxProgram(xsMachine* the) { return cast(sxSlot) the.stackTop[-1 - mxProgramStackIndex]; }
+package(xs) sxSlot* mxRealm(xsMachine* the) { return mxProgram(the).value.reference.next.value.module_.realm; }
+package(xs) xsSlot* slot(sxSlot* slot) { return cast(xsSlot*) slot; }
+package(xs) sxSlot* next(const xsSlot slot) {
+  return cast(sxSlot*) slot.data[0];
 }
-package(xs) xsSlot* next(const xsSlot* slot) {
-  return cast(xsSlot*) slot.data[0];
+package(xs) sxSlot* next(const xsSlot* slot) {
+  return cast(sxSlot*) slot.data[0];
 }
 
 /// The kind of JS source code.
@@ -161,13 +163,12 @@ class Script {
         // https://github.com/Moddable-OpenSource/moddable/blob/OS201116/documentation/xs/XS%20Platforms.md#modules
         fxRunModule(the, cast(xsSlot*) &machine.realm, XS_NO_ID, script.copy);
       else {
-        auto realmClosures = cast(sxSlot*) machine.realm.next.next;
-        auto program = cast(sxSlot) the.mxProgram;
+        auto realmClosures = machine.realm.next.next;
         fxRunScript(
           the, script.copy,
           cast(sxSlot*) &machine.realm, null,
           realmClosures.value.reference, null,
-          program.value.reference
+          the.mxProgram.value.reference
         );
       }
     }();

--- a/source/xs/script.d
+++ b/source/xs/script.d
@@ -6,13 +6,55 @@
 module xs.script;
 
 import std.conv : to;
+import std.range.primitives : isInputRange;
 
 import xs;
+import xs.bindings.enums;
+import xs.bindings.structs;
+
+package(xs) enum mxProgramStackIndex = 2;
+package(xs) auto mxProgram(xsMachine* the) { return the.stackTop[-1 - mxProgramStackIndex]; }
+package(xs) xsSlot* next(const xsSlot slot) {
+  return cast(xsSlot*) slot.data[0];
+}
+package(xs) xsSlot* next(const xsSlot* slot) {
+  return cast(xsSlot*) slot.data[0];
+}
+
+/// The kind of JS source code.
+enum ScriptKind {
+  ///
+  program,
+  ///
+  module_,
+}
 
 package(xs) extern(C) {
+  enum Flags : txU4 {
+    mxParserFlags = mxCFlag | mxDebugFlag | mxProgramFlag,
+    mxCFlag = 1 << 0,
+    mxDebugFlag = 1 << 1,
+    mxEvalFlag = 1 << 2,
+    mxProgramFlag = 1 << 3,
+    mxStrictFlag = 1 << 4,
+    mxSuperFlag = 1 << 5,
+    mxTargetFlag = 1 << 6,
+    mxFieldFlag = 1 << 15,
+  }
+
+  /// A function which, given a pointer to some stream of characters, returns each successive character until [`EOF`](https://dlang.org/library/core/stdc/stdio/eof.html) is returned.
+  ///
+  /// i.e. A structure that satisfies [`isInputRange`](https://dlang.org/phobos/std_range_primitives.html#isInputRange)
+  alias txGetter = int function(void* stream);
+  txScript* fxParseScript(xsMachine* the, void* stream, txGetter getter, Flags flags);
+  void fxDeleteScript(txScript* script);
   bool fxIsLoadingModule(xsMachine* the, xsSlot* realm, txID moduleID);
   void fxResolveModule(
     xsMachine* the, xsSlot* realm, txID moduleID, txScript* script, void* data, xsDestructor destructor
+  );
+  void fxRunScript(
+    xsMachine* the, txScript* script,
+    sxSlot* _this, sxSlot* _target, sxSlot* environment, sxSlot* object, sxSlot* module_
   );
   void fxRunModule(xsMachine* the, xsSlot* realm, txID moduleID, txScript* script);
   void fxRunImport(xsMachine* the, xsSlot* realm, txID id);
@@ -20,65 +62,117 @@ package(xs) extern(C) {
   xsSlot* fxNewRealmInstance(xsMachine* the);
 }
 
-package(xs) enum mxProgramStackIndex = 2;
-package(xs) enum mxProgram(alias xsMachine* the) = the.stackTop[-1 - mxProgramStackIndex];
+private extern(C) int getter(T)(void* stream) if (isInputRange!T) {
+  import core.stdc.stdio : EOF;
+  import std.range : empty, front, popFront;
+
+  T s = *(cast(T*) stream);
+  if (s.empty) return EOF;
+  const char_ = s.front;
+  s.popFront();
+  *(cast(T*) stream) = s;
+  return char_.to!int;
+}
+
+// TODO: Switch to `fxStringGetter`?
+private txGetter stringGetter = &getter!string;
+
+///
+class JSParseException : Exception {
+  import std.exception : basicExceptionCtors;
+
+  mixin basicExceptionCtors;
+}
 
 /// A JavaScript script or entry point module.
 class Script {
   private Machine machine;
   package(xs) const txScript script;
-
   private const void* callback;
+
+  /// The kind of JS source code of this script.
+  const ScriptKind kind;
+  ///
+	const string path = "";
   ///
 	const txS1[] symbolsBuffer;
   ///
 	const txS1[] codeBuffer;
   ///
 	const txS1[] hostsBuffer;
+
+  /// Construct a new script given its source code and load it, executing its global scope in the given `machine`.
   ///
-	const string path;
+  /// Throws: `JSParseException` when the script fails to parse
+  /// Throws: `JSException` when the JS VM is aborted with the `xsUnhandledExceptionExit` status while executing the script's global scope
+  this(Machine machine, string source, string* path = null, ScriptKind kind = ScriptKind.program) {
+    import std.exception : enforce;
 
-  /// Construct a new script given its source code.
-  this(Machine machine, string path, const(ubyte[]) source) {
     this.machine = machine;
-    this.script = txScript();
-
     callback = null;
-    symbolsBuffer = [];
-    codeBuffer = [];
-    hostsBuffer = [];
-    this.path = path;
+    this.kind = kind;
+    if (path !is null) this.path = (*path).dup;
 
-    // TODO: https://github.com/Moddable-OpenSource/moddable/blob/5639abb24b6d725554969dc0be5822edb54a4a08/documentation/xs/XS%20Platforms.md#eval
-    assert(0, "Not implemented");
-  }
+    // https://github.com/Moddable-OpenSource/moddable/blob/5639abb24b6d725554969dc0be5822edb54a4a08/documentation/xs/XS%20Platforms.md#eval
+    auto sourceStream = source.dup;
+    txScript* unmanagedScript = null;
+    const zone = (scope xsMachine* the) => {
+      auto parserFlags = Flags.mxParserFlags;
+      if (kind == ScriptKind.module_) parserFlags |= Flags.mxStrictFlag;
+      else assert(kind == ScriptKind.program);
+      unmanagedScript = fxParseScript(the, &sourceStream, stringGetter, parserFlags);
+    }();
+    xsHostZone!zone(machine.the);
+    enforce!JSParseException(unmanagedScript !is null, "Failed to parse script");
 
-  package(xs) this(Machine machine, const txScript* script) {
-    import std.string : fromStringz;
+    script = *unmanagedScript.managedCopy;
+    // The result of `fxParseScript` is not managed memory
+    fxDeleteScript(unmanagedScript);
 
-    this.machine = machine;
-    this.script = *script;
-
-    callback = script.callback;
     symbolsBuffer = script.symbolsBuffer[0..script.symbolsSize];
     codeBuffer = script.codeBuffer[0..script.codeSize];
     hostsBuffer = script.hostsBuffer[0..script.hostsSize];
+
+    run();
+  }
+  /// Construct a script given compiled VM byte code.
+  this(Machine machine, const txScript* byteCode, ScriptKind kind = ScriptKind.program) {
+    import std.string : fromStringz;
+
+    this.machine = machine;
+    script = *byteCode;
+    callback = script.callback;
+    this.kind = kind;
     path = script.path.fromStringz.to!string;
+
+    symbolsBuffer = script.symbolsBuffer[0..script.symbolsSize];
+    codeBuffer = script.codeBuffer[0..script.codeSize];
+    hostsBuffer = script.hostsBuffer[0..script.hostsSize];
+
+    run();
   }
 
-  ///
-  /// Throws: `JSException` when the JS VM is aborted with the `xsUnhandledExceptionExit` status.
-  void run() inout {
+  /// Execute this script's global scope.
+  private void run() {
     auto zone = (scope xsMachine* the) => {
-      // https://github.com/Moddable-OpenSource/moddable/blob/5639abb24b6d725554969dc0be5822edb54a4a08/documentation/xs/XS%20Platforms.md#modules
-      fxRunModule(the, cast(xsSlot*) &machine.realm, XS_NO_ID, cast(txScript*) script.copy);
+      if (kind == ScriptKind.module_)
+        // https://github.com/Moddable-OpenSource/moddable/blob/OS201116/documentation/xs/XS%20Platforms.md#modules
+        fxRunModule(the, cast(xsSlot*) &machine.realm, XS_NO_ID, script.copy);
+      else {
+        auto realmClosures = cast(sxSlot*) machine.realm.next.next;
+        auto program = cast(sxSlot) the.mxProgram;
+        fxRunScript(
+          the, script.copy,
+          cast(sxSlot*) &machine.realm, null,
+          realmClosures.value.reference, null,
+          program.value.reference
+        );
+      }
     }();
     try {
       machine.the.xsHostZone!zone;
     } catch (JSException unhandledInVm) {
-      // TODO: Get the JS error that was thrown
-      const JSValue exception = null;
-      throw new JSException(unhandledInVm.msg, this, exception, unhandledInVm.file, unhandledInVm.line);
+      throw new JSException(unhandledInVm.msg, this, unhandledInVm.file, unhandledInVm.line);
     }
   }
 }
@@ -109,11 +203,21 @@ version(unittest) {
 }
 
 unittest {
-  import std.exception : assertThrown;
+  import std.exception : assertNotThrown, assertThrown;
+  import std.typecons : tuple;
+
+  auto machine = new Machine("test-script", Machine.defaultCreation);
+  assertNotThrown!JSException(
+    new Script(machine, "const foo = 'bar';")
+  );
+  assertThrown!JSException(
+    new Script(machine, "throw new Error('unhandled err');")
+  );
+  destroy(machine);
 
   auto script = helloWorldScript();
-  auto machine = new Machine("test-script", Machine.defaultCreation, [&script]);
-  assertThrown!JSException(machine.scripts[0].run());
-
+  assertThrown!JSException(
+    machine = new Machine("test-compiled-script", Machine.defaultCreation, [tuple(&script, ScriptKind.module_)])
+  );
   destroy(machine);
 }


### PR DESCRIPTION
- Add runtime compilation/execution of JS snippets
- Add `JSObject` abstraction
- Add `JSClass` abstraction